### PR TITLE
Safe transformation of action to class to avoid breaking the lib

### DIFF
--- a/lib/croods/resource/policy.rb
+++ b/lib/croods/resource/policy.rb
@@ -26,7 +26,7 @@ module Croods
       end
 
       def policy_scope_name(action)
-        "#{model_name}#{action.to_s.camelize}Scope"
+        "#{model_name}#{action.to_s.titleize.gsub(/\ /, '')}Scope"
       end
 
       def create_policy!


### PR DESCRIPTION
According to [this issue](https://github.com/SeasonedSoftware/croods-rails/issues/25), when you use a dashed action the lib will break.
This PR avoids this crash but does not add the feature of actually creating the routes and so on because it is an anti-pattern and would require more work.

Instead of crashing croods it will show something like:
```
AbstractController::ActionNotFound:
       The action 'high_lighted' could not be found for ProjectsController
```