### PR TITLE
Enable sorting method without arguments

### DIFF
--- a/docs/docs/sorting.md
+++ b/docs/docs/sorting.md
@@ -21,10 +21,13 @@ There are two ways of using `sort_by`:
 sort_by foo: :asc, bar: desc
 ```
 
-2. If it is the name of a method, it must accept two arguments, order_by and order. Declare that method inside the model.
+2. If it is the name of a method, it can accept **zero** or **two** arguments. Declare that method inside the model.
    The method should return an ActiveRecord::Relation. It will be chained with other methods of the collection (pagination, etc.)
 
-The `index` action will then **expect** the query parameters `order_by` and `order`, and call that method with these parameters. You can do complex sorting logic with that, for example:
+The `index` action accepts the query parameters `order_by` and `order`. If `order_by` is present and the method exists, it will call that method with both parameters.
+Protip: pass these query parameters only if your methods accepts them. If you intend to use the index endpoint without the sorting parameters, remember to make the arguments optional in your method.
+
+Example of a sorting method without parameters:
 
 ```ruby
 # app/resources/lists/resource
@@ -35,7 +38,26 @@ module Lists
     sort_by :sorting
 
     extend_model do
-      def self.sorting(order_by, order)
+      def self.sorting # without parameters
+        joins(:project).order('projects.name asc')
+      end
+    end
+  end
+end
+```
+
+Example of a sorting method with parameters:
+
+```ruby
+# app/resources/lists/resource
+module Lists
+  class Resource < ApplicationResource
+    filter_by :project, optional: true
+
+    sort_by :sorting
+
+    extend_model do
+      def self.sorting(order_by, order) # with parameters
         sort = parse_sorting_names(order_by) || 'created_at'
         joins(:project).order(sort => order || 'asc')
       end

--- a/docs/docs/sorting.md
+++ b/docs/docs/sorting.md
@@ -21,11 +21,22 @@ There are two ways of using `sort_by`:
 sort_by foo: :asc, bar: desc
 ```
 
-2. If it is the name of a method, it can accept **zero** or **two** arguments. Declare that method inside the model.
+2. If it is the name of a method, it can accept zero, one or two arguments. Declare that method inside the model.
    The method should return an ActiveRecord::Relation. It will be chained with other methods of the collection (pagination, etc.)
 
-The `index` action accepts the query parameters `order_by` and `order`. If `order_by` is present and the method exists, it will call that method with both parameters.
-Protip: pass these query parameters only if your methods accepts them. If you intend to use the index endpoint without the sorting parameters, remember to make the arguments optional in your method.
+The `index` action accepts the query parameters `order_by` and `order`. It will call the sorting method with the parameters that it receives, so take care to make your method respond to the correct number of parameters.
+
+```ruby
+if order_by && order
+  # call sorting method with order_by, order
+elsif order_by
+  # call sorting method with order_by
+elsif order
+  # call sorting method with order
+else
+  # call sorting method without arguments
+end
+```
 
 Example of a sorting method without parameters:
 
@@ -38,7 +49,7 @@ module Lists
     sort_by :sorting
 
     extend_model do
-      def self.sorting # without parameters
+      def self.sorting # without arguments
         joins(:project).order('projects.name asc')
       end
     end
@@ -57,7 +68,8 @@ module Lists
     sort_by :sorting
 
     extend_model do
-      def self.sorting(order_by, order) # with parameters
+      def self.sorting(order_by, order) # with arguments
+        # if order_by isn't present and order is, the method will receive the latter as the first argument, so be careful with the usage
         sort = parse_sorting_names(order_by) || 'created_at'
         joins(:project).order(sort => order || 'asc')
       end
@@ -71,3 +83,5 @@ module Lists
   end
 end
 ```
+
+The method could also receive only one of the parameters. Just be careful because if you accept `order_by` and the request happens to pass only the parameter `order`, it will be passed as the first and only argument.

--- a/lib/croods/controller/collection.rb
+++ b/lib/croods/controller/collection.rb
@@ -27,13 +27,27 @@ module Croods
         end
       end
 
+      def order_by
+        params[:order_by].presence
+      end
+
+      def order
+        params[:order].presence
+      end
+
+      # rubocop:disable Metrics/AbcSize
       def sort_by_method(list)
-        if params[:order_by].present?
-          list.public_send(resource.sort_by, params[:order_by], params[:order])
+        if order_by && order
+          list.public_send(resource.sort_by, order_by, order)
+        elsif order_by
+          list.public_send(resource.sort_by, order_by)
+        elsif order
+          list.public_send(resource.sort_by, order)
         else
           list.public_send(resource.sort_by)
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def sort(list)
         if resource.sort_by_method?

--- a/lib/croods/controller/collection.rb
+++ b/lib/croods/controller/collection.rb
@@ -27,9 +27,17 @@ module Croods
         end
       end
 
+      def sort_by_method(list)
+        if params[:order_by].present?
+          list.public_send(resource.sort_by, params[:order_by], params[:order])
+        else
+          list.public_send(resource.sort_by)
+        end
+      end
+
       def sort(list)
         if resource.sort_by_method?
-          list.public_send(resource.sort_by, params[:order_by], params[:order])
+          sort_by_method(list)
         else
           list.order(resource.sort_by)
         end

--- a/todos/app/resources/lists/resource.rb
+++ b/todos/app/resources/lists/resource.rb
@@ -20,8 +20,8 @@ module Lists
     end
 
     extend_model do
-      def self.sorting(order_by, order)
-        sort = parse_sorting_names(order_by) || 'created_at'
+      def self.sorting(order_by = 'created_at', order = 'asc')
+        sort = parse_sorting_names(order_by)
         joins(:project).order(sort => order || 'asc')
       end
 

--- a/todos/app/resources/lists/resource.rb
+++ b/todos/app/resources/lists/resource.rb
@@ -22,7 +22,7 @@ module Lists
     extend_model do
       def self.sorting(order_by = 'created_at', order = 'asc')
         sort = parse_sorting_names(order_by)
-        joins(:project).order(sort => order || 'asc')
+        joins(:project).order(sort => order)
       end
 
       def self.parse_sorting_names(order_by)

--- a/todos/app/resources/users/resource.rb
+++ b/todos/app/resources/users/resource.rb
@@ -6,6 +6,14 @@ module Users
     authorize :admin, on: :destroy
     authorize :admin, :supervisor, on: %i[create update]
 
+    sort_by :custom_sort
+
     public_actions :index, :show
+
+    extend_model do
+      def custom_sort
+        order(:email)
+      end
+    end
   end
 end


### PR DESCRIPTION
Value proposal: allow devs to use a sorting method that does whatever even if they don't want to pass params. Like sorting users by the number of reviews they wrote.